### PR TITLE
add support for showTree cache

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -121,7 +121,7 @@ func (svc *ConfigService) ShowTree(ctx context.Context, path string) (map[string
 	for _, component := range strings.Split(path, " ") {
 		obj, ok := val[component].(map[string]any)
 		if !ok {
-			return nil, errors.New("value missing from configuration tree returned by server")
+			return nil, nil
 		}
 		val = obj
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -135,6 +135,9 @@ func (svc *ConfigService) ShowTree(ctx context.Context, path string) (map[string
 	if err != nil {
 		return nil, err
 	}
+	if obj == nil {
+		return nil, nil
+	}
 
 	result, ok := obj.(map[string]any)
 	if !ok {

--- a/client/util.go
+++ b/client/util.go
@@ -75,7 +75,7 @@ func flatten(result *[][]string, value any, path string) error {
 }
 
 // Flatten a multi level object into a flat list of {key, value} pairs
-func Flatten(tree map[string]any) ([][]string, error) {
+func Flatten(tree any) ([][]string, error) {
 	res := [][]string{}
 	err := flatten(&res, tree, "")
 	return res, err


### PR DESCRIPTION
Where there are many Terraform resources for vyos the refresh can take minutes as the the API calls are serialized.

This PR adds support to retrieve the configuration only once per Terraform apply/refresh action - this allows to have only 1 call refreshing any number of objects.

In addition I also made the following changes:
- remove some warnings as error messages should not start with capital letters nor end with dots
- added support to set or delete passing an slice of commands instead of a map which does not allow for duplicates (which happens for vyos list values.