### PR TITLE
feat(container-image): added container image service

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,8 @@ type Client struct {
 
 	mutex *sync.Mutex
 
-	Config *ConfigService
+	Config          *ConfigService
+	ContainerImages *ContainerImageService
 }
 type ConfigService struct{ client *Client }
 
@@ -35,9 +36,11 @@ func NewWithClient(c *http.Client, url string, key string) *Client {
 		&sync.Mutex{},
 
 		nil,
+		nil,
 	}
 
 	client.Config = &ConfigService{client}
+	client.ContainerImages = &ContainerImageService{client}
 
 	return client
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"testing"
 
 	"context"
@@ -9,6 +10,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func make_client(t *testing.T) (*Client, context.Context) {
@@ -26,7 +29,7 @@ func make_client(t *testing.T) (*Client, context.Context) {
 		},
 	}
 	http := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout:   10 * time.Second,
 		Transport: tr,
 	}
 
@@ -117,7 +120,6 @@ func TestIntegration_Config_ShowRoot(t *testing.T) {
 	}
 }
 
-
 func TestIntegration_Config_SetValue(t *testing.T) {
 	client, ctx := make_client(t)
 	err := client.Config.Set(ctx, "service ntp listen-address", "1.2.3.4")
@@ -150,7 +152,7 @@ func TestIntegration_Config_SetMap(t *testing.T) {
 
 	payload := map[string]any{
 		"reboot-on-panic": "",
-		"startup-beep": "",
+		"startup-beep":    "",
 	}
 	err := client.Config.Set(ctx, "system option", payload)
 	if err != nil {
@@ -270,4 +272,20 @@ func TestIntegration_Config_Delete(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestIntegration_HandleNonSuccess(t *testing.T) {
+	client, ctx := make_client(t)
+
+	_, err := client.Request(ctx, "foo", map[string]any{
+		"op": "foo",
+	})
+	assert.ErrorContains(
+		t,
+		err,
+		fmt.Sprintf(
+			"received non-successful (404) response from vyos api (%s/foo)",
+			client.url,
+		),
+	)
 }

--- a/client/containerImageService.go
+++ b/client/containerImageService.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type ContainerImageService struct{ client *Client }
+type ContainerImage struct {
+	Name    string
+	Tag     string
+	ImageID string
+}
+
+// Add container image
+func (svc *ContainerImageService) Add(ctx context.Context, image string) error {
+	_, err := svc.client.Request(ctx, "container-image", map[string]any{
+		"op":   "add",
+		"name": image,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete container image
+func (svc *ContainerImageService) Delete(ctx context.Context, image string) error {
+	_, err := svc.client.Request(ctx, "container-image", map[string]any{
+		"op":   "delete",
+		"name": image,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Return the list of container images
+func (svc *ContainerImageService) Show(ctx context.Context) ([]ContainerImage, error) {
+	resp, err := svc.client.Request(ctx, "container-image", map[string]any{
+		"op": "show",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	data, ok := resp.(string)
+	if !ok {
+		return nil, errors.New("received unexpected repsonse format from server")
+	}
+	return parseImages(data)
+}
+
+var imageLinePattern = regexp.MustCompile(`^(?P<name>[^\s]+)\s{2,}(?P<tag>[^\s]+)\s{2,}(?P<imageId>[^\s]+)`)
+
+func parseImages(data string) ([]ContainerImage, error) {
+	if data == "" {
+		return []ContainerImage{}, nil
+	}
+	lines := strings.Split(strings.TrimSpace(data), "\n")
+	match, _ := regexp.MatchString("REPOSITORY\\s{2,}TAG\\s{2,}IMAGE ID\\s{2,}", lines[0])
+	if !match {
+		return nil, fmt.Errorf("container image response header (%s) does not match expected format", lines[0])
+	}
+
+	images := []ContainerImage{}
+	j := len(lines)
+	for i := 1; i < j; i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		match := reSubMatchMap(imageLinePattern, line)
+		images = append(images, ContainerImage{
+			Name:    match["name"],
+			Tag:     match["tag"],
+			ImageID: match["imageId"],
+		})
+	}
+	return images, nil
+}
+
+func reSubMatchMap(r *regexp.Regexp, str string) map[string]string {
+	match := r.FindStringSubmatch(str)
+	subMatchMap := make(map[string]string)
+	for i, name := range r.SubexpNames() {
+		if i != 0 {
+			subMatchMap[name] = match[i]
+		}
+	}
+
+	return subMatchMap
+}

--- a/client/containerImageService_test.go
+++ b/client/containerImageService_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestUnit_ParseImages(t *testing.T) {
-	images, err := parseImages("REPOSITORY                   TAG         IMAGE ID      CREATED       SIZE\ndocker.io/library/alpine     3.18.0      5e2b554c1c45  4 weeks ago   7.62 MB\n")
+	images, err := parseImages("sudo: unable to resolve host 62b1b7ccea6c: System error\nREPOSITORY                   TAG         IMAGE ID      CREATED       SIZE\ndocker.io/library/alpine     3.18.0      5e2b554c1c45  4 weeks ago   7.62 MB\n")
 	assert.NoError(t, err, "expected no error parsing images")
 	assert.Len(t, images, 1, "expected exactly 1 container image")
 	assert.Equal(t, "docker.io/library/alpine", images[0].Name, "image name must be equal")

--- a/client/containerImageService_test.go
+++ b/client/containerImageService_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnit_ParseImages(t *testing.T) {
+	images, err := parseImages("REPOSITORY                   TAG         IMAGE ID      CREATED       SIZE\ndocker.io/library/alpine     3.18.0      5e2b554c1c45  4 weeks ago   7.62 MB\n")
+	assert.NoError(t, err, "expected no error parsing images")
+	assert.Len(t, images, 1, "expected exactly 1 container image")
+	assert.Equal(t, "docker.io/library/alpine", images[0].Name, "image name must be equal")
+	assert.Equal(t, "3.18.0", images[0].Tag, "image tag must be equal")
+	assert.Equal(t, "5e2b554c1c45", images[0].ImageID, "image id must be equal")
+}
+
+func TestIntegration_Containers_Show(t *testing.T) {
+	client, ctx := make_client(t)
+	err := client.ContainerImages.Add(ctx, "alpine:3.17.3")
+	assert.NoError(t, err, "expected no error adding container image")
+	images, err := client.ContainerImages.Show(ctx)
+	assert.NoError(t, err, "expected no error showing container images")
+	var actual *ContainerImage = nil
+	for _, image := range images {
+		if image.Name == "docker.io/library/alpine" && image.Tag == "3.17.3" {
+			actual = &image
+		}
+	}
+	assert.NotNil(t, actual, "expected to find container image for alpine:3.17.3")
+}
+
+func TestIntegration_Containers_Delete(t *testing.T) {
+	client, ctx := make_client(t)
+	err := client.ContainerImages.Add(ctx, "alpine:3.17.3")
+	assert.NoError(t, err, "expected no error adding container image")
+	err = client.ContainerImages.Delete(ctx, "alpine:3.17.3")
+	assert.NoError(t, err, "expected no error deleting container image")
+
+	images, err := client.ContainerImages.Show(ctx)
+	assert.NoError(t, err, "expected no error showing container images")
+	var actual *ContainerImage = nil
+	for _, image := range images {
+		if image.Name == "docker.io/library/alpine" && image.Tag == "3.17.3" {
+			actual = &image
+		}
+	}
+	assert.Nil(t, actual, "expected to NOT find container image for alpine:3.17.3")
+}

--- a/client/containerImageService_test.go
+++ b/client/containerImageService_test.go
@@ -7,43 +7,88 @@ import (
 )
 
 func TestUnit_ParseImages(t *testing.T) {
-	images, err := parseImages("sudo: unable to resolve host 62b1b7ccea6c: System error\nREPOSITORY                   TAG         IMAGE ID      CREATED       SIZE\ndocker.io/library/alpine     3.18.0      5e2b554c1c45  4 weeks ago   7.62 MB\n")
+	// correct empty response
+	images, err := parseImages("")
 	assert.NoError(t, err, "expected no error parsing images")
-	assert.Len(t, images, 1, "expected exactly 1 container image")
-	assert.Equal(t, "docker.io/library/alpine", images[0].Name, "image name must be equal")
-	assert.Equal(t, "3.18.0", images[0].Tag, "image tag must be equal")
-	assert.Equal(t, "5e2b554c1c45", images[0].ImageID, "image id must be equal")
+	assert.Len(t, images, 0, "expected exactly 0 container images")
+
+	header := "REPOSITORY                   TAG         IMAGE ID      CREATED       SIZE"
+	name0, tag0, id0 := "docker.io/library/alpine0", "3.18.0.0", "5e2b554c1c450"
+	name1, tag1, id1 := "docker.io/library/alpine1", "3.18.0.1", "5e2b554c1c451"
+	image0 := name0 + "  " + tag0 + "  " + id0 + "  40 weeks ago  7.620 MB"
+	image1 := name1 + "  " + tag1 + "  " + id1 + "  41 weeks ago  7.621 MB"
+
+	// correct response
+	images, err = parseImages(header + "\n" + image0 + "\n" + image1)
+	assert.NoError(t, err, "expected no error parsing images")
+	assert.Len(t, images, 2, "expected exactly 2 container images")
+	assert.Equal(t, name0, images[0].Name, "image name must be equal")
+	assert.Equal(t, tag0, images[0].Tag, "image tag must be equal")
+	assert.Equal(t, id0, images[0].ImageID, "image id must be equal")
+	assert.Equal(t, name1, images[1].Name, "image name must be equal")
+	assert.Equal(t, tag1, images[1].Tag, "image tag must be equal")
+	assert.Equal(t, id1, images[1].ImageID, "image id must be equal")
+
+	// should ignore empty lines and lines preceding header
+	images, err = parseImages("bogus\n \n\n" + image0 + "\n" + header + "\n" + image0 + "\n\n\n" + image1)
+	assert.NoError(t, err, "expected no error parsing images")
+	assert.Len(t, images, 2, "expected exactly 2 container images")
+
+	// should error when no header present
+	images, err = parseImages(image0 + "\n" + image1)
+	assert.Error(t, err, "expected error parsing images")
+
+	// should error on malformed image entry
+	images, err = parseImages(header + "\n" + name0 + "  " + tag0)
+	assert.Error(t, err, "expected error parsing images")
+	images, err = parseImages(header + "\n" + "$")
+	assert.Error(t, err, "expected error parsing images")
 }
 
 func TestIntegration_Containers_Show(t *testing.T) {
 	client, ctx := make_client(t)
+
+	// add image
 	err := client.ContainerImages.Add(ctx, "alpine:3.17.3")
 	assert.NoError(t, err, "expected no error adding container image")
+
+	// show newly added image
 	images, err := client.ContainerImages.Show(ctx)
 	assert.NoError(t, err, "expected no error showing container images")
-	var actual *ContainerImage = nil
+
+	// should find newly added image
+	found := false
 	for _, image := range images {
 		if image.Name == "docker.io/library/alpine" && image.Tag == "3.17.3" {
-			actual = &image
+			found = true
+			break
 		}
 	}
-	assert.NotNil(t, actual, "expected to find container image for alpine:3.17.3")
+	assert.True(t, found, "expected to find container image for alpine:3.17.3")
 }
 
 func TestIntegration_Containers_Delete(t *testing.T) {
 	client, ctx := make_client(t)
+
+	// add image
 	err := client.ContainerImages.Add(ctx, "alpine:3.17.3")
 	assert.NoError(t, err, "expected no error adding container image")
+
+	// delete image
 	err = client.ContainerImages.Delete(ctx, "alpine:3.17.3")
 	assert.NoError(t, err, "expected no error deleting container image")
 
+	// show images
 	images, err := client.ContainerImages.Show(ctx)
 	assert.NoError(t, err, "expected no error showing container images")
-	var actual *ContainerImage = nil
+
+	// should not find previously deleted image
+	found := false
 	for _, image := range images {
 		if image.Name == "docker.io/library/alpine" && image.Tag == "3.17.3" {
-			actual = &image
+			found = true
+			break
 		}
 	}
-	assert.Nil(t, actual, "expected to NOT find container image for alpine:3.17.3")
+	assert.False(t, found, "expected to NOT find container image for alpine:3.17.3")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,14 @@ module github.com/foltik/vyos-client-go
 
 go 1.18
 
-require github.com/go-resty/resty/v2 v2.6.0
+require (
+	github.com/go-resty/resty/v2 v2.6.0
+	github.com/stretchr/testify v1.8.4
+)
 
-require golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-resty/resty/v2 v2.6.0 h1:joIR5PNLM2EFqqESUjCMGXrWmXNHEU9CEiK813oKYS4=
 github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -7,3 +13,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Allows managing container images. I didn't see vyos documentation for the endpoint, but found the source code for it [here](https://github.com/vyos/vyos-1x/blob/b01a7a06ae63c2f0bbeb60a8cef567f4d333be30/src/services/vyos-http-api-server#L597-L626).

### TODO
- [x] update vyos rolling docker image, so integration tests can actually pass